### PR TITLE
Fix a bug that occurs when neither GSL or narray are available.

### DIFF
--- a/lib/tf-idf-similarity/collection.rb
+++ b/lib/tf-idf-similarity/collection.rb
@@ -2,9 +2,11 @@
 begin
   require 'gsl'
 rescue LoadError
-  require 'narray'
-rescue LoadError
-  require 'matrix'
+  begin
+    require 'narray'
+  rescue LoadError
+    require 'matrix'
+  end
 end
 
 class TfIdfSimilarity::Collection


### PR DESCRIPTION
The second begin/rescue statement should be nested in the first rescue statement for the LoadError to be caught that time around.
