### PR TITLE
Add option to allow tokens to not be processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ tokens = UnicodeUtils.each_word(text).to_a - ['and', 'the', 'to']
 document1 = TfIdfSimilarity::Document.new(text, :tokens => tokens)
 ```
 
+If you do not want the gem to do any processing of the tokens you pass then use the option `:process_tokens => false`. In general you want this set to `true` as process tokens will handle downcasing and filtering of invalid tokens. This option is only valid if you are passing your own tokens.
+
+```ruby
+document1 = TfIdfSimilarity::Document.new(text, :tokens => tokens, :process_tokens => false)
+```
+
 [Read the documentation at RubyDoc.info.](http://rubydoc.info/gems/tf-idf-similarity)
 
 ## Speed

--- a/lib/tf-idf-similarity/document.rb
+++ b/lib/tf-idf-similarity/document.rb
@@ -14,12 +14,14 @@ module TfIdfSimilarity
     # @param [Hash] opts optional arguments
     # @option opts [String] :id the document's identifier
     # @option opts [Array] :tokens the document's tokenized text
+    # @option opts [Boolean] :process_tokens if false will not filter or check validation of tokens
     # @option opts [Hash] :term_counts the number of times each term appears
     # @option opts [Integer] :size the number of tokens in the document
     def initialize(text, opts = {})
-      @text   = text
-      @id     = opts[:id] || object_id
-      @tokens = opts[:tokens]
+      @text           = text
+      @id             = opts[:id] || object_id
+      @tokens         = opts[:tokens]
+      @process_tokens = opts[:process_tokens].nil? || opts[:tokens].nil? ? true : opts[:process_tokens]
 
       if opts[:term_counts]
         @term_counts = opts[:term_counts]
@@ -52,10 +54,15 @@ module TfIdfSimilarity
     # Tokenizes the text and counts terms and total tokens.
     def set_term_counts_and_size
       tokenize(text).each do |word|
-        token = Token.new(word)
-        if token.valid?
-          term = token.lowercase_filter.classic_filter.to_s
-          @term_counts[term] += 1
+        if @process_tokens
+          token = Token.new(word)
+          if token.valid?
+            term = token.lowercase_filter.classic_filter.to_s
+            @term_counts[term] += 1
+            @size += 1
+          end
+        else
+          @term_counts[word] += 1
           @size += 1
         end
       end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -27,6 +27,14 @@ module TfIdfSimilarity
       Document.new(text, :tokens => tokens)
     end
 
+    let :document_with_tokens_no_processing do
+      Document.new(text, :tokens => tokens, :process_tokens => false)
+    end
+
+    let :document_no_processing do
+      Document.new(text, :process_tokens => false)
+    end
+
     let :document_with_term_counts do
       Document.new(text, :term_counts => {'bar' => 5, 'baz' => 10})
     end
@@ -90,6 +98,15 @@ module TfIdfSimilarity
         document_with_tokens.term_counts.should == {'foo-foo' => 1, 'bar' => 2}
       end
 
+      it 'should return the term counts if tokens given and processing is set to false' do
+        document_with_tokens_no_processing.term_counts.should == {"FOO-foo"=>1, "BAR"=>1, "bar"=>1, "\r\n\t"=>1, "123"=>1, "!@#"=>1}
+      end
+
+      it 'should return the term counts if processing is set to false' do
+        # ignores processing option if tokens are not passed.
+        document_no_processing.term_counts.should == {'foo' => 2, 'bar' => 2}
+      end
+
       it 'should return no term counts if no text given' do
         document_without_text.term_counts.should == {}
       end
@@ -108,6 +125,15 @@ module TfIdfSimilarity
         document_with_tokens.terms.sort.should == ['bar', 'foo-foo']
       end
 
+      it 'should return the term if tokens given and processing is set to false' do
+        document_with_tokens_no_processing.terms.sort.should == ["\r\n\t", "!@#", "123", "BAR", "FOO-foo", "bar"]
+      end
+
+      it 'should return the term if processing is set to false' do
+        # ignores processing option if tokens are not passed.
+        document_no_processing.terms.sort.should == ['bar', 'foo']
+      end
+
       it 'should return no terms if no text given' do
         document_without_text.terms.should == []
       end
@@ -124,6 +150,15 @@ module TfIdfSimilarity
 
       it 'should return the term count if tokens given' do
         document_with_tokens.term_count('foo-foo').should == 1
+      end
+
+      it 'should return the term count if tokens given and processing is set to false' do
+        document_with_tokens_no_processing.term_count('FOO-foo').should == 1
+      end
+
+      it 'should return the term count if processing is set to false' do
+        # ignores processing option if tokens are not passed.
+        document_no_processing.term_count('foo').should == 2
       end
 
       it 'should return no term count if no text given' do


### PR DESCRIPTION
You may or may not be open to this change. No worries if you don't want to merge it. The idea is to give the option to not process the tokens (downcasing / filtering / checking for validity) if a user passes their own tokens. There may be times where a user has pre-processed the tokens already, so in that case the gem processing them would be unnecessary. In other cases a user *may* want results without downcasing or filtering. For example 'Apple' the company and 'apple' the fruit get merged into the same term when downcased. I know in 99% of the cases it is better to downcase, but I don't think it hurts to give the user the option.

Regardless if you accept or reject this one it would be great to get a new release after your decision (for the previous commit on the classic_filter).