### PR TITLE
Require delegate in token.rb

### DIFF
--- a/lib/tf-idf-similarity/token.rb
+++ b/lib/tf-idf-similarity/token.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-
+require 'delegate'
 # A token.
 #
 # @note We can add more filters from Solr and stem using Porter's Snowball.


### PR DESCRIPTION
When trying to run the gem from IRB I receive the following error ```NameError: uninitialized constant TfIdfSimilarity::SimpleDelegator``` which I think can be resolved by this PR.