### PR TITLE
Extract Tokenizer from Document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Gemfile.lock
 doc/*
 pkg/*
+coverage/*

--- a/lib/tf-idf-similarity.rb
+++ b/lib/tf-idf-similarity.rb
@@ -1,9 +1,6 @@
 require 'forwardable'
 require 'set'
 
-require 'unicode_utils/downcase'
-require 'unicode_utils/each_word'
-
 module TfIdfSimilarity
 end
 

--- a/lib/tf-idf-similarity/document.rb
+++ b/lib/tf-idf-similarity/document.rb
@@ -1,3 +1,5 @@
+require 'tf-idf-similarity/tokenizer'
+
 # A document.
 module TfIdfSimilarity
   class Document
@@ -19,7 +21,8 @@ module TfIdfSimilarity
     def initialize(text, opts = {})
       @text   = text
       @id     = opts[:id] || object_id
-      @tokens = opts[:tokens]
+      @tokens = Array(opts[:tokens]).map { |t| TfIdfSimilarity::Token.new(t) } if opts[:tokens]
+      @tokenizer = opts[:tokenizer] || TfIdfSimilarity::Tokenizer.new
 
       if opts[:term_counts]
         @term_counts = opts[:term_counts]
@@ -51,10 +54,9 @@ module TfIdfSimilarity
 
     # Tokenizes the text and counts terms and total tokens.
     def set_term_counts_and_size
-      tokenize(text).each do |word|
-        token = Token.new(word)
+      tokenize(text).each do |token|
         if token.valid?
-          term = token.lowercase_filter.classic_filter.to_s
+          term = token.to_s
           @term_counts[term] += 1
           @size += 1
         end
@@ -76,7 +78,7 @@ module TfIdfSimilarity
     # @see http://unicode.org/reports/tr29/#Default_Word_Boundaries
     # @see http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters#solr.StandardTokenizerFactory
     def tokenize(text)
-      @tokens || UnicodeUtils.each_word(text)
+      @tokens || @tokenizer.tokenize(text)
     end
   end
 end

--- a/lib/tf-idf-similarity/token.rb
+++ b/lib/tf-idf-similarity/token.rb
@@ -1,5 +1,7 @@
 # coding: utf-8
 require 'delegate'
+require 'unicode_utils/downcase'
+require 'unicode_utils/each_word'
 
 # A token.
 #
@@ -46,6 +48,11 @@ module TfIdfSimilarity
     # @see http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters#solr.ClassicFilterFactory
     def classic_filter
       self.class.new(self.gsub('.', '').sub(/['`’]s\z/, ''))
+    end
+
+    def to_s
+      UnicodeUtils.downcase(self).
+        gsub('.', '').sub(/['`’]s\z/, '').to_s
     end
   end
 end

--- a/lib/tf-idf-similarity/tokenizer.rb
+++ b/lib/tf-idf-similarity/tokenizer.rb
@@ -1,0 +1,21 @@
+require 'tf-idf-similarity/token'
+
+require 'unicode_utils/each_word'
+
+# A Tokenizer using UnicodeUtils to tokenize a givne text.
+#
+# @see https://github.com/lang/unicode_utils
+module TfIdfSimilarity
+  class Tokenizer
+
+    # Tokenizes a text.
+    #
+    # @param [String] text
+    # @return [Enumerator] an enumerator of Token objects
+    def tokenize(text)
+      UnicodeUtils.each_word(text).map do |word|
+        TfIdfSimilarity::Token.new(word)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The current version's `TfIdfSimilarity::Document#tokenize` depends on `unicode_utils`. 
The gme `unicode_utils` does not tokenize texts in some languages like Japanese. 

This pull-request provides updates in order for developers to implement a tokenizer by themselves. 
I made a sample script to demonstrate the use of this PR: https://gist.github.com/satoryu/0183a4eba365cc67e28988a09f3035b3
