### PR TITLE
support Numo::NArray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
+  - 3.1
+  - 3.2
   - ruby-head
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   - MATRIX_LIBRARY=narray
   - MATRIX_LIBRARY=nmatrix
   - MATRIX_LIBRARY=matrix
+  - MATRIX_LIBRARY=numo
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,22 @@ rvm:
   - ruby-head
 matrix:
   allow_failures:
+    - rvm: 3.0
+      env: MATRIX_LIBRARY=gsl
+    - rvm: 3.1
+      env: MATRIX_LIBRARY=gsl
+    - rvm: 3.2
+      env: MATRIX_LIBRARY=gsl
     - rvm: ruby-head
       env: MATRIX_LIBRARY=gsl
     - rvm: ruby-head
-      env: MATRIX_LIBRARY=narray
+      env: MATRIX_LIBRARY=matrix
     - rvm: ruby-head
+      env: MATRIX_LIBRARY=narray
+    - rvm: 3.2
       env: MATRIX_LIBRARY=nmatrix
     - rvm: ruby-head
-      env: MATRIX_LIBRARY=matrix
+      env: MATRIX_LIBRARY=nmatrix
 env:
   - MATRIX_LIBRARY=gsl
   - MATRIX_LIBRARY=narray

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'rb-gsl', '~> 1.16.0.2' if ENV['MATRIX_LIBRARY'] == 'gsl'
 gem 'narray', '~> 0.6.0.0' if ENV['MATRIX_LIBRARY'] == 'narray'
 gem 'nmatrix', '~> 0.2' if ENV['MATRIX_LIBRARY'] == 'nmatrix'
+gem 'numo-narray', '~> 0.9.2.1' if ENV['MATRIX_LIBRARY'] == 'numo'
 
 # Specify your gem's dependencies in the gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rb-gsl', '~> 1.16.0.2' if ENV['MATRIX_LIBRARY'] == 'gsl'
+gem 'matrix' if ENV['MATRIX_LIBRARY'] == 'matrix'
 gem 'narray', '~> 0.6.0.0' if ENV['MATRIX_LIBRARY'] == 'narray'
 gem 'nmatrix', '~> 0.2' if ENV['MATRIX_LIBRARY'] == 'nmatrix'
 gem 'numo-narray', '~> 0.9.2.1' if ENV['MATRIX_LIBRARY'] == 'numo'

--- a/lib/tf-idf-similarity/model.rb
+++ b/lib/tf-idf-similarity/model.rb
@@ -15,7 +15,7 @@ module TfIdfSimilarity
       array = Array.new(terms.size) do |i|
         idf = inverse_document_frequency(terms[i])
         Array.new(documents.size) do |j|
-          term_frequency(documents[j], terms[i]) * idf
+          (term_frequency(documents[j], terms[i]) * idf).to_f
         end
       end
 

--- a/lib/tf-idf-similarity/term_count_model.rb
+++ b/lib/tf-idf-similarity/term_count_model.rb
@@ -37,6 +37,8 @@ module TfIdfSimilarity
         case @library
         when :gsl, :narray
           row(index).where.size
+        when :numo
+          (row(index).ne 0).where.size
         when :nmatrix
           row(index).each.count(&:nonzero?)
         else
@@ -57,7 +59,7 @@ module TfIdfSimilarity
       index = terms.index(term)
       if index
         case @library
-        when :gsl, :narray
+        when :gsl, :narray, :numo
           row(index).sum
         when :nmatrix
           row(index).each.reduce(0, :+) # NMatrix's `sum` method is slower

--- a/spec/bm25_model_spec.rb
+++ b/spec/bm25_model_spec.rb
@@ -82,7 +82,12 @@ module TfIdfSimilarity
 
       describe '#term_frequency_inverse_document_frequency' do
         it 'should return negative infinity' do
-          model.tfidf(document, 'foo').should be_nan
+          case MATRIX_LIBRARY
+          when :numo
+            model.tfidf(document, 'foo').isnan.should eq 1
+          else
+            model.tfidf(document, 'foo').should be_nan
+          end
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,8 @@ when :gsl
   require 'gsl'
 when :narray
   require 'narray'
+when :numo
+  require 'numo/narray'
 when :nmatrix
   require 'nmatrix'
 else


### PR DESCRIPTION
- support Numo::NArray `narray` is no longer under development. So added a option for a newer version  `numo-narray` can be used.
- add Ruby 3.0 or later
- test: Skip Ruby versions with some libraries
