### PR TITLE
Fix numo normalize MatrixMethods

### DIFF
--- a/lib/tf-idf-similarity/matrix_methods.rb
+++ b/lib/tf-idf-similarity/matrix_methods.rb
@@ -18,7 +18,7 @@ module TfIdfSimilarity
         norm[norm.where2[1]] = 1.0 # avoid division by zero
         NMatrix.refer(@matrix / norm) # must be NMatrix for matrix multiplication
       when :numo
-        norm = Numo::NMath.sqrt((@matrix ** 2).sum(0).reshape(1, @matrix.shape[0]))
+        norm = Numo::NMath.sqrt((@matrix ** 2).sum(0).reshape(1, @matrix.shape[1]))
         norm[(norm.eq 0).where] = 1.0 # avoid division by zero
         (@matrix / norm)
       when :nmatrix # @see https://github.com/SciRuby/nmatrix/issues/38


### PR DESCRIPTION
Hi :)

I had an issue with the `similarity_matrix` when using the `numo` library


Wasn't sure the best way to add a test for this.  Tte issue can be reproduced if we updates this:

https://github.com/jpmckinney/tf-idf-similarity/blob/5eda3d513c825829298c24369b82ffc74ba46bf4/spec/tf_idf_model_spec.rb#L97-L104 

and add an extra document like this:


```ruby
    context 'with documents' do
      let :documents do
        [
          document,
          document_with_tokens,
          document_without_text,
          document_with_term_counts,
          document_with_term_counts,

        ]
      end
```

We would have the following error from the numo library:

```
  1) TfIdfSimilarity::TfIdfModel with documents #similarity_matrix should return the similarity matrix
     Failure/Error: norm = Numo::NMath.sqrt((@matrix ** 2).sum(0).reshape(1, @matrix.shape[0]))

     ArgumentError:
       Total size must be same
     # ./lib/tf-idf-similarity/matrix_methods.rb:21:in `reshape'
     # ./lib/tf-idf-similarity/matrix_methods.rb:21:in `normalize'
     # ./lib/tf-idf-similarity/model.rb:44:in `similarity_matrix'
     # ./spec/tf_idf_model_spec.rb:34:in `similarity_matrix_values'
     # ./spec/tf_idf_model_spec.rb:195:in `block (4 levels) in <module:TfIdfSimilarity>'
```

